### PR TITLE
feat: observable stateful delegation

### DIFF
--- a/kstate-core/src/commonMain/kotlin/com/jstarczewski/kstate/ObservableStateful.kt
+++ b/kstate-core/src/commonMain/kotlin/com/jstarczewski/kstate/ObservableStateful.kt
@@ -1,0 +1,39 @@
+package com.jstarczewski.kstate
+
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Implements a core logic of a [Stateful] property that calls callback functions when changed.
+ */
+abstract class ObservableStateful<T : Any>(receiver: StateHolder, initialState: T) : ReadWriteProperty<StateHolder, T> {
+
+    private var value by receiver.stateful(initialState)
+
+    /**
+     *  The callback that is triggered just before an attempt to update the state value.
+     *  When this callback is called, the state's value has not yet changed.
+     *  The value of the property is being set to the new value if the callback returns true;
+     *  otherwise, the new value gets ignored and the state is left at its previous value.
+     */
+    protected open fun beforeChange(property: KProperty<*>, oldValue: T, newValue: T): Boolean = true
+
+    /**
+     * The callback that is called after a property update is made.
+     * When this callback is used, the property's value has already changed.
+     */
+    protected open fun afterChange(property: KProperty<*>, oldValue: T, newValue: T) {}
+
+    override fun getValue(thisRef: StateHolder, property: KProperty<*>): T {
+        return value
+    }
+
+    override fun setValue(thisRef: StateHolder, property: KProperty<*>, value: T) {
+        val oldValue = this.value
+        if (!beforeChange(property, oldValue, value)) {
+            return
+        }
+        this.value = value
+        afterChange(property, oldValue, value)
+    }
+}

--- a/kstate-core/src/commonMain/kotlin/com/jstarczewski/kstate/Stateful.kt
+++ b/kstate-core/src/commonMain/kotlin/com/jstarczewski/kstate/Stateful.kt
@@ -1,5 +1,9 @@
+@file:JvmName("StatefulExt")
+
 package com.jstarczewski.kstate
 
+import kotlin.jvm.JvmName
+import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 /**
@@ -37,5 +41,40 @@ expect open class Stateful<T : Any> {
  * @return [Stateful] of type T
  */
 expect fun <T : Any> StateHolder.stateful(
-    initialValue: T
+    initialValue: T,
 ): Stateful<T>
+
+/**
+ * Returns a property delegate for a [Stateful] of value [T] that calls a specified callback function when changed.
+ *
+ * This function can be used with `by` syntax
+ *
+ * ```
+ * var stateful : String by observableStateful("Example") { oldValue, newValue ->
+ *   logger.info("newValue: $newValue, oldValue: $oldValue")
+ * }
+ * ```
+ * To update param created by `stateful` simply write new value to it. This will lead to changes on platform side.
+ * Note that write operation to a field is not synchronized and synchronization is on user side.
+ * ```
+ * var stateful : String by observableStateful("Example") { oldValue, newValue ->
+ *   logger.info("newValue: $newValue, oldValue: $oldValue")
+ * }
+ *
+ * fun update() {
+ *     stateful = "Other example" // newValue: Other example, oldValue: Example
+ * }
+ * ```
+ *
+ * @param initialValue initial value of type T
+ * @param onChange the callback which is called after the change of the property is made.
+ * The value of the property has already been changed when this callback is invoked.
+ * @receiver [StateHolder]
+ * @return [Stateful] of type T
+ */
+inline fun <T : Any> StateHolder.observableStateful(
+    initialValue: T,
+    crossinline onChange: (oldValue: T, newValue: T) -> Unit,
+): ReadWriteProperty<StateHolder, T> = object : ObservableStateful<T>(this, initialValue) {
+    override fun afterChange(property: KProperty<*>, oldValue: T, newValue: T) = onChange(oldValue, newValue)
+}

--- a/kstate-core/src/commonTest/kotlin/com.jstarczewski.kstate/CommonStateHolderTest.kt
+++ b/kstate-core/src/commonTest/kotlin/com.jstarczewski.kstate/CommonStateHolderTest.kt
@@ -1,6 +1,7 @@
 package com.jstarczewski.kstate
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -21,5 +22,26 @@ class CommonStateHolderTest {
         }
         stateHolder.isLoading = true
         assertTrue(stateHolder.isLoading)
+    }
+
+    @Test
+    fun `observableStateful calls callback after the state changed`() {
+        var actualOldValue = ""
+        var actualNewValue = ""
+        val stateHolder = object : StateHolder by StateHolder() {
+            var title by observableStateful("An empty") { oldValue, newValue ->
+                actualOldValue = oldValue
+                actualNewValue = newValue
+            }
+        }
+        stateHolder.title = "The title"
+        assertEquals(
+            expected = "An empty",
+            actual = actualOldValue
+        )
+        assertEquals(
+            expected = "The title",
+            actual = actualNewValue
+        )
     }
 }

--- a/kstate-core/src/commonTest/kotlin/com.jstarczewski.kstate/ObservableStatefulTest.kt
+++ b/kstate-core/src/commonTest/kotlin/com.jstarczewski.kstate/ObservableStatefulTest.kt
@@ -1,0 +1,106 @@
+package com.jstarczewski.kstate
+
+import kotlin.reflect.KProperty
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ObservableStatefulTest {
+
+    @Test
+    fun `should call afterChange when state holder set a new value`() {
+        var callCounter = 0
+        val stateHolder = object : StateHolder by StateHolder() {
+            var observableStateful by object : ObservableStateful<String>(this, "") {
+                override fun afterChange(property: KProperty<*>, oldValue: String, newValue: String) {
+                    callCounter++
+                }
+            }
+        }
+        stateHolder.observableStateful = "test"
+        assertEquals(
+            expected = 1,
+            actual = callCounter,
+            message = "afterChange should be called once",
+        )
+    }
+
+    @Test
+    fun `should set a new value when state holder set a new value and beforeChange return true`() {
+        val initialValue = "initial"
+        val theNewValue = "test"
+        var callCounter = 0
+        var actualOldValue = ""
+        var actualNewValue = ""
+        val stateHolder = object : StateHolder by StateHolder() {
+            var observableStateful by object : ObservableStateful<String>(this, initialValue) {
+                override fun beforeChange(property: KProperty<*>, oldValue: String, newValue: String): Boolean {
+                    actualNewValue = newValue
+                    actualOldValue = oldValue
+                    callCounter++
+                    return true
+                }
+            }
+        }
+        stateHolder.observableStateful = theNewValue
+        assertEquals(
+            expected = 1,
+            actual = callCounter,
+            message = "beforeChange should be called once",
+        )
+        assertEquals(
+            expected = theNewValue,
+            actual = stateHolder.observableStateful,
+            message = "current value does not equal to the new value",
+        )
+        assertEquals(
+            expected = initialValue,
+            actual = actualOldValue,
+            message = "old value does not equal to the initial value",
+        )
+        assertEquals(
+            expected = theNewValue,
+            actual = actualNewValue,
+            message = "new value does not equal to the new value",
+        )
+    }
+
+    @Test
+    fun `should not set a new value when state holder set a new value and beforeChange returns false`() {
+        val initialValue = "initial"
+        var callCounter = 0
+        val theNewValue = "test"
+        var actualOldValue = ""
+        var actualNewValue = ""
+        val stateHolder = object : StateHolder by StateHolder() {
+            var observableStateful by object : ObservableStateful<String>(this, initialValue) {
+                override fun beforeChange(property: KProperty<*>, oldValue: String, newValue: String): Boolean {
+                    actualNewValue = newValue
+                    actualOldValue = oldValue
+                    callCounter++
+                    return false
+                }
+            }
+        }
+        stateHolder.observableStateful = "test"
+        assertEquals(
+            expected = 1,
+            actual = callCounter,
+            message = "beforeChange should be called once",
+        )
+        assertEquals(
+            expected = initialValue,
+            actual = stateHolder.observableStateful,
+            message = "beforeChange should reject the new value and remain as it were",
+        )
+        assertEquals(
+            expected = initialValue,
+            actual = actualOldValue,
+            message = "old value does not equal to the initial value",
+        )
+        assertEquals(
+            expected = theNewValue,
+            actual = actualNewValue,
+            message = "new value does not equal to the new value",
+        )
+    }
+}


### PR DESCRIPTION
While tracing state transitions, I realized the significance of having a logging system comparable to the one found in the Flutter BLoC framework. This led me to develop a delegation property that effectively communicates whether the state has changed or requires modification.